### PR TITLE
Implement document processing pipeline

### DIFF
--- a/parsers/form3461.py
+++ b/parsers/form3461.py
@@ -1,0 +1,31 @@
+from typing import Dict, List
+from pydantic import BaseModel
+
+class Form3461(BaseModel):
+    importer: str | None = None
+    entry_number: str | None = None
+    port: str | None = None
+
+
+def extract_key_values(blocks: List[Dict]) -> Dict[str, str]:
+    kv = {}
+    keys = {b["Id"]: b for b in blocks if b["BlockType"] == "KEY_VALUE_SET" and "KEY" in b.get("EntityTypes", [])}
+    vals = {b["Id"]: b for b in blocks if b["BlockType"] == "KEY_VALUE_SET" and "VALUE" in b.get("EntityTypes", [])}
+    for key in keys.values():
+        for rel in key.get("Relationships", []):
+            if rel["Type"] == "VALUE":
+                val_block = vals.get(rel["Ids"][0])
+                if val_block:
+                    k = key.get("Text", "").strip()
+                    v = val_block.get("Text", "").strip()
+                    if k:
+                        kv[k] = v
+    return kv
+
+def parse_form(blocks: List[Dict]) -> Form3461:
+    kv = extract_key_values(blocks)
+    return Form3461(
+        importer=kv.get("Importer"),
+        entry_number=kv.get("Entry No."),
+        port=kv.get("Port")
+    )

--- a/parsers/invoice.py
+++ b/parsers/invoice.py
@@ -1,0 +1,40 @@
+from typing import List, Dict, Tuple
+from sqlmodel import Session, select
+from models import InvoiceLine, ColumnMapping
+from services import parser
+
+class InvoiceParseResult:
+    def __init__(self, lines: List[InvoiceLine] | None = None, needs_mapping: bool = False, sample_lines: List[str] | None = None):
+        self.lines = lines or []
+        self.needs_mapping = needs_mapping
+        self.sample_lines = sample_lines or []
+
+def parse_invoice(blocks: List[Dict], seller_id: str, db: Session) -> InvoiceParseResult:
+    rows = parser.textract_tables(blocks)
+    mapping_rec = db.exec(
+        select(ColumnMapping).where(ColumnMapping.seller_id == seller_id)
+    ).first()
+    mapping = mapping_rec.mapping if mapping_rec else parser.detect_columns(rows)
+
+    if not mapping:
+        sample = [b["Text"] for b in blocks if b.get("BlockType") == "LINE"][:10]
+        return InvoiceParseResult(needs_mapping=True, sample_lines=sample)
+
+    qty_i = mapping["qty_col"]
+    val_i = mapping["val_col"]
+    lines: List[InvoiceLine] = []
+    for row in rows.values():
+        try:
+            qty_cell = next(c for c in row if c["ColumnIndex"] == qty_i)
+            val_cell = next(c for c in row if c["ColumnIndex"] == val_i)
+            qty = int(parser._clean(qty_cell["Text"]))
+            value = float(parser._clean(val_cell["Text"]).replace(",", ""))
+            desc = " ".join(
+                c["Text"] for c in row if c["ColumnIndex"] not in (qty_i, val_i)
+            ).strip()
+            if desc:
+                lines.append(InvoiceLine(description=desc, quantity=qty, value=value))
+        except (StopIteration, ValueError):
+            continue
+    return InvoiceParseResult(lines=lines)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,6 @@ uvicorn==0.34.3
 uvloop==0.21.0
 watchfiles==1.0.5
 websockets==15.0.1
+celery==5.4.0
+redis==5.0.4
+PyJWT==2.8.0

--- a/routers/__init__.py
+++ b/routers/__init__.py
@@ -1,5 +1,6 @@
 #from .auth import router as auth_router 
 from .billing import router as billing_router
-from .entry import router as entry_router 
+from .entry import router as entry_router
+from .documents import router as documents_router
 
-all_routers = [billing_router, entry_router]
+all_routers = [billing_router, entry_router, documents_router]

--- a/routers/auth.py
+++ b/routers/auth.py
@@ -1,0 +1,21 @@
+import os
+from fastapi import HTTPException, status, Depends
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
+import jwt
+
+_JWT_SECRET = os.getenv("SUPABASE_JWT_SECRET", "test")
+_auth_scheme = HTTPBearer()
+
+class TokenData:
+    def __init__(self, sub: str):
+        self.sub = sub
+
+def verify_supabase_jwt(token: HTTPAuthorizationCredentials = Depends(_auth_scheme)) -> str:
+    try:
+        payload = jwt.decode(token.credentials, _JWT_SECRET, algorithms=["HS256"])
+    except Exception:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "Invalid JWT")
+    user_id = payload.get("sub") or payload.get("user_id")
+    if not user_id:
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED, "user id missing")
+    return user_id

--- a/routers/documents.py
+++ b/routers/documents.py
@@ -1,0 +1,60 @@
+from fastapi import APIRouter, UploadFile, File, BackgroundTasks, Depends, HTTPException, status
+from fastapi.responses import JSONResponse, StreamingResponse
+from .auth import verify_supabase_jwt
+from services import ocr
+from services.tasks import process_textract_job
+from models import ColumnMappingIn, ColumnMapping
+from db import engine
+from sqlmodel import Session, select
+import json
+
+router = APIRouter(prefix="/documents", tags=["documents"])
+
+ALLOWED_TYPES = {"invoice", "3461", "7501"}
+
+@router.post("/upload", status_code=202)
+async def upload_document(bg: BackgroundTasks, doc_type: str, file: UploadFile = File(...), user_id: str = Depends(verify_supabase_jwt)):
+    if doc_type not in ALLOWED_TYPES:
+        raise HTTPException(400, "unknown doc_type")
+    if file.content_type not in ("application/pdf", "image/jpeg", "image/png"):
+        raise HTTPException(400, "Only PDF/JPG/PNG accepted")
+
+    data = await file.read()
+    s3_key = ocr.upload_to_s3(data)
+    job_id = ocr.start_job(s3_key)
+
+    process_textract_job.delay(job_id, doc_type, user_id)
+
+    return {"job_id": job_id}
+
+@router.get("/parse/{doc_type}/{job_id}")
+def get_parse(doc_type: str, job_id: str, user_id: str = Depends(verify_supabase_jwt)):
+    try:
+        resp = ocr.s3.get_object(Bucket=ocr.BUCKET, Key=f"{ocr.RESULT_PREFIX}{job_id}_parsed.json")
+    except ocr.s3.exceptions.NoSuchKey:
+        raise HTTPException(404, "processing")
+    data = json.loads(resp["Body"].read())
+    return data
+
+@router.post("/column-mapping", status_code=204)
+def save_mapping(payload: ColumnMappingIn, user_id: str = Depends(verify_supabase_jwt)):
+    with Session(engine) as db:
+        rec = db.exec(select(ColumnMapping).where(ColumnMapping.seller_id == user_id)).first()
+        if rec:
+            rec.mapping = payload.dict()
+        else:
+            rec = ColumnMapping(seller_id=user_id, mapping=payload.dict())
+        db.add(rec)
+        db.commit()
+    return JSONResponse(status_code=204)
+
+@router.get("/pdf/{doc_type}/{job_id}")
+def get_pdf(doc_type: str, job_id: str, user_id: str = Depends(verify_supabase_jwt)):
+    key = f"{ocr.RESULT_PREFIX}{job_id}_parsed.json"  # pdf path uses same prefix
+    pdf_key = f"pdf/{job_id}.pdf"
+    try:
+        obj = ocr.s3.get_object(Bucket=ocr.BUCKET, Key=pdf_key)
+    except ocr.s3.exceptions.NoSuchKey:
+        raise HTTPException(404, "pdf not ready")
+    return StreamingResponse(obj["Body"], media_type="application/pdf")
+

--- a/services/__init__.py
+++ b/services/__init__.py
@@ -1,0 +1,2 @@
+from . import ocr
+from . import tasks

--- a/services/ocr.py
+++ b/services/ocr.py
@@ -32,6 +32,17 @@ def _save_result(job_id: str, blocks: List[Dict]) -> None:
         Body=json.dumps(blocks).encode("utf-8"),
     )
 
+def fetch_blocks(job_id: str) -> List[Dict]:
+    resp = s3.get_object(Bucket=BUCKET, Key=f"{RESULT_PREFIX}{job_id}.json")
+    return json.loads(resp["Body"].read())
+
+def save_parsed(job_id: str, data: Dict) -> None:
+    s3.put_object(
+        Bucket=BUCKET,
+        Key=f"{RESULT_PREFIX}{job_id}_parsed.json",
+        Body=json.dumps(data).encode("utf-8"),
+    )
+
 # ── main polling function (runs in background thread) ─────────────────────
 def poll_job(job_id: str, *, max_try=60, wait=5) -> None:
     """

--- a/services/tasks.py
+++ b/services/tasks.py
@@ -1,0 +1,40 @@
+import os
+from celery import Celery
+from typing import Dict, List
+from services import ocr
+from services import parser
+from parsers import invoice as invoice_parser
+from parsers import form3461, form7501
+import json
+
+CELERY_BROKER = os.getenv("CELERY_BROKER_URL", "redis://localhost:6379/0")
+CELERY_BACKEND = os.getenv("CELERY_BACKEND_URL", CELERY_BROKER)
+
+celery_app = Celery("easyentry", broker=CELERY_BROKER, backend=CELERY_BACKEND)
+
+@celery_app.task
+def process_textract_job(job_id: str, doc_type: str, user_id: str) -> str:
+    # poll job until finished
+    ocr.poll_job(job_id)
+    blocks = ocr.fetch_blocks(job_id)
+
+    result: Dict = {"status": "ok"}
+    if doc_type == "invoice":
+        from sqlmodel import Session
+        from db import engine
+        with Session(engine) as db:
+            res = invoice_parser.parse_invoice(blocks, user_id, db)
+            result.update({"needs_mapping": res.needs_mapping,
+                           "data": [l.dict() for l in res.lines],
+                           "sample_lines": res.sample_lines})
+    elif doc_type == "3461":
+        form = form3461.parse_form(blocks)
+        result["data"] = form.dict()
+    elif doc_type == "7501":
+        form = form7501.parse_form(blocks)
+        result["data"] = form.dict()
+    else:
+        result = {"status": "error", "detail": "unknown doc_type"}
+
+    ocr.save_parsed(job_id, result)
+    return job_id


### PR DESCRIPTION
## Summary
- add Celery-based job processing
- include parsers for invoice and form PDFs
- store parsed results on S3
- add `/documents` router with upload/parse/PDF endpoints
- implement simple Supabase JWT verification

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6840dafb7f40832a81b2ac2675457bfa